### PR TITLE
Various changes and improvements

### DIFF
--- a/examples/example.c
+++ b/examples/example.c
@@ -6,13 +6,15 @@
 // create microrl object and pointer on it
 microrl_t rl;
 microrl_t * prl = &rl;
+char microrl_cmdline[_COMMAND_LINE_LEN];
+ring_history_t microrl_history;
 
 //*****************************************************************************
 int main (void/*int argc, char ** argv*/)
 {
 	init ();
 	// call init with ptr to microrl instance and print callback
-	microrl_init (prl, print);
+	microrl_init (prl, microrl_cmdline, &microrl_history, print);
 	// set callback for execute
 	microrl_set_execute_callback (prl, execute);
 

--- a/src/microrl.c
+++ b/src/microrl.c
@@ -316,22 +316,16 @@ static void terminal_print_line (microrl_t * pThis, int pos, int cursor)
 }
 
 //*****************************************************************************
-void microrl_init (microrl_t * pThis, void (*print) (const char *)) 
+void microrl_init (microrl_t * pThis, char cmdline_buffer[_COMMAND_LINE_LEN],
+		ring_history_t *history, void (*print)(const char*))
 {
-	memset(pThis->cmdline, 0, _COMMAND_LINE_LEN);
-#ifdef _USE_HISTORY
-	memset(pThis->ring_hist.ring_buf, 0, _RING_HISTORY_LEN);
-	pThis->ring_hist.begin = 0;
-	pThis->ring_hist.end = 0;
-	pThis->ring_hist.cur = 0;
-#endif
-	pThis->cmdlen =0;
-	pThis->cursor = 0;
-	pThis->execute = NULL;
-	pThis->get_completion = NULL;
-#ifdef _USE_CTLR_C
-	pThis->sigint = NULL;
-#endif
+	memset(pThis, 0, sizeof(microrl_t));
+	memset(history, 0, sizeof(ring_history_t));
+	memset(cmdline_buffer, 0, _COMMAND_LINE_LEN);
+
+	pThis->cmdline = cmdline_buffer;
+	pThis->ring_hist = history;
+
 	pThis->prompt_str = prompt_default;
 	pThis->print = print;
 #ifdef _ENABLE_INIT_PROMPT
@@ -361,7 +355,7 @@ void microrl_set_sigint_callback (microrl_t * pThis, void (*sigintf)(void))
 #ifdef _USE_ESC_SEQ
 static void hist_search (microrl_t * pThis, int dir)
 {
-	int len = hist_restore_line (&pThis->ring_hist, pThis->cmdline, dir);
+	int len = hist_restore_line (pThis->ring_hist, pThis->cmdline, dir);
 	if (len >= 0) {
 		pThis->cursor = pThis->cmdlen = len;
 		terminal_reset_cursor (pThis);
@@ -533,13 +527,12 @@ void new_line_handler(microrl_t * pThis){
 	terminal_newline (pThis);
 #ifdef _USE_HISTORY
 	if (pThis->cmdlen > 0)
-		hist_save_line (&pThis->ring_hist, pThis->cmdline, pThis->cmdlen);
+		hist_save_line (pThis->ring_hist, pThis->cmdline, pThis->cmdlen);
 #endif
 	status = split (pThis, pThis->cmdlen, tkn_arr);
 	if (status == -1){
 		//          pThis->print ("ERROR: Max token amount exseed\n");
-		pThis->print ("ERROR:too many tokens");
-		pThis->print (ENDL);
+		pThis->print ("ERROR:too many tokens" ENDL);
 	}
 	if ((status > 0) && (pThis->execute != NULL))
 		pThis->execute (status, tkn_arr);
@@ -548,7 +541,7 @@ void new_line_handler(microrl_t * pThis){
 	pThis->cursor = 0;
 	memset(pThis->cmdline, 0, _COMMAND_LINE_LEN);
 #ifdef _USE_HISTORY
-	pThis->ring_hist.cur = 0;
+	pThis->ring_hist->cur = 0;
 #endif
 }
 

--- a/src/microrl.h
+++ b/src/microrl.h
@@ -56,10 +56,10 @@
 // history struct, contain internal variable
 // history store in static ring buffer for memory saving
 typedef struct {
-	char ring_buf [_RING_HISTORY_LEN];
 	int begin;
 	int end;
 	int cur;
+	char ring_buf [_RING_HISTORY_LEN];
 } ring_history_t;
 #endif
 
@@ -72,23 +72,24 @@ typedef struct {
 #if (defined(_ENDL_CRLF) || defined(_ENDL_LFCR))
 	char tmpch;
 #endif
-#ifdef _USE_HISTORY
-	ring_history_t ring_hist;          // history object
-#endif
-	char * prompt_str;                 // pointer to prompt string
-	char cmdline [_COMMAND_LINE_LEN];  // cmdline buffer
+	char *cmdline;                     // cmdline buffer
 	int cmdlen;                        // last position in command line
 	int cursor;                        // input cursor
+	void (*print) (const char *);                                     // ptr to 'print' callback
 	int (*execute) (int argc, const char * const * argv );            // ptr to 'execute' callback
 	char ** (*get_completion) (int argc, const char * const * argv ); // ptr to 'completion' callback
-	void (*print) (const char *);                                     // ptr to 'print' callback
 #ifdef _USE_CTLR_C
 	void (*sigint) (void);
+#endif
+	char * prompt_str;                 // pointer to prompt string
+#ifdef _USE_HISTORY
+	ring_history_t *ring_hist;          // history object
 #endif
 } microrl_t;
 
 // init internal data, calls once at start up
-void microrl_init (microrl_t * pThis, void (*print)(const char*));
+void microrl_init (microrl_t * pThis, char cmdline_buffer[_COMMAND_LINE_LEN],
+		ring_history_t *history, void (*print)(const char*));
 
 // set echo mode (true/false), using for disabling echo for password input
 // echo mode will enabled after user press Enter.


### PR DESCRIPTION
- Don't put control characters to the command line buffer
- Avoid processing of unknown escape sequences
- Replace strcat()s with strcpy()s in stdio-less configuration
- Command history always ends with an empty line
- Move variable definitions out of for() statements
- Remove tkn_arr from microrl_t and use a stack to store this array
- Remove static variables and move them to microrl_t structure
- Move command line and history buffers out of microrl_t and place pointers there. Also, reorder some structure fields and use a memset() for initialization. These changes considerably reduce executable code size because field offsets are much smaller and they can be usually computed with a single instruction.
