### PR TITLE
Use stdbool to avoid polluting namespace with non-C99 macros

### DIFF
--- a/src/microrl.h
+++ b/src/microrl.h
@@ -3,8 +3,7 @@
 
 #include "config.h"
 
-#define true  1
-#define false 0
+#include <stdbool.h>
 
  /* define the Key codes */
 #define KEY_NUL 0 /**< ^@ Null character */


### PR DESCRIPTION
Since the README already demands a C99 compiler, I figure it shouldn't be much trouble to use stdbool instead of the existing macros for this - those pollute the namespace of the project including microrl.h, which could conflict with stdbool.h being used elsewhere.