### PR TITLE
Add a feature for Ctrl-R to retype prompt and command

### DIFF
--- a/src/microrl.c
+++ b/src/microrl.c
@@ -665,6 +665,14 @@ void microrl_insert_char (microrl_t * pThis, int ch)
 				microrl_backspace (pThis);
 				terminal_print_line (pThis, pThis->cursor, pThis->cursor);
 			break;
+			//-----------------------------------------------------
+			case KEY_DC2: // ^R
+				terminal_newline (pThis);
+				print_prompt (pThis);
+				terminal_reset_cursor (pThis);
+				terminal_print_line (pThis, 0, pThis->cursor);
+			break;
+			//-----------------------------------------------------
 #ifdef _USE_CTLR_C
 			case KEY_ETX:
 			if (pThis->sigint != NULL)


### PR DESCRIPTION
Cisco's IOS CLI and some operating system CLIs (including some old ones like TENEX) implement Ctrl-R to retype the command prompt plus whatever partial command has been input so far.  This is useful when there may be other processes outputting messages on the terminal where microrl is running.