### PR TITLE
history: null-terminate restored history line

### DIFF
--- a/examples/avr_misc/avr_misc.c
+++ b/examples/avr_misc/avr_misc.c
@@ -1,4 +1,4 @@
-#include "../../src/config.h"
+#include "../../src/microrl.h"
 #include <string.h>
 #include <stdlib.h>
 #include <avr/io.h>

--- a/examples/microrl_config.h
+++ b/examples/microrl_config.h
@@ -5,8 +5,6 @@ Autor: Eugene Samoylov aka Helius (ghelius@gmail.com)
 #ifndef _MICRORL_CONFIG_H_
 #define _MICRORL_CONFIG_H_
 
-#define MICRORL_LIB_VER "1.5.1"
-
 /*********** CONFIG SECTION **************/
 /*
 Command line length, define cmdline buffer size. Set max number of chars + 1,

--- a/examples/unix_misc/unix_misc.c
+++ b/examples/unix_misc/unix_misc.c
@@ -4,7 +4,7 @@
 #include <sys/ioctl.h>
 #include <unistd.h> 
 #include <string.h>
-#include "../../src/config.h"
+#include "../../src/microrl.h"
 
 //*****************************************************************************
 //dummy function, no need on linux-PC

--- a/src/microrl.c
+++ b/src/microrl.c
@@ -363,6 +363,7 @@ static void hist_search (microrl_t * pThis, int dir)
 {
 	int len = hist_restore_line (&pThis->ring_hist, pThis->cmdline, dir);
 	if (len >= 0) {
+		pThis->cmdline[len] = '\0';
 		pThis->cursor = pThis->cmdlen = len;
 		terminal_reset_cursor (pThis);
 		terminal_print_line (pThis, 0, pThis->cursor);

--- a/src/microrl.h
+++ b/src/microrl.h
@@ -1,7 +1,9 @@
 #ifndef _MICRORL_H_
 #define _MICRORL_H_
 
-#include "config.h"
+#include "microrl_config.h"
+
+#define MICRORL_LIB_VER "1.5.1"
 
 #define true  1
 #define false 0


### PR DESCRIPTION
Fixes bug where scrolling past a longer line (foobar) before restoring a short line (baz) results in a combined command (bazbar) if the user ends the line without editing it.