### PR TITLE
Add smart newline handling

### DIFF
--- a/src/microrl.c
+++ b/src/microrl.c
@@ -568,37 +568,19 @@ void microrl_insert_char (microrl_t * pThis, int ch)
 			pThis->escape = 0;
 	} else {
 #endif
+		if (ch == KEY_CR || ch == KEY_LF) {
+			// Only trigger a newline if ch doen't follow its companion's
+			// triggering a newline.
+			if (pThis->last_endl == (ch == KEY_CR ? KEY_LF : KEY_CR)) {
+				pThis->last_endl = 0;      // ignore char, but clear newline state
+			} else {
+				pThis->last_endl = ch;
+				new_line_handler(pThis);
+			}
+			return;
+		}
+		pThis->last_endl = 0;
 		switch (ch) {
-			//-----------------------------------------------------
-#ifdef _ENDL_CR
-			case KEY_CR:
-				new_line_handler(pThis);
-			break;
-			case KEY_LF:
-			break;
-#elif defined(_ENDL_CRLF)
-			case KEY_CR:
-				pThis->tmpch = KEY_CR;
-			break;
-			case KEY_LF:
-			if (pThis->tmpch == KEY_CR)
-				new_line_handler(pThis);
-			break;
-#elif defined(_ENDL_LFCR)
-			case KEY_LF:
-				pThis->tmpch = KEY_LF;
-			break;
-			case KEY_CR:
-			if (pThis->tmpch == KEY_LF)
-				new_line_handler(pThis);
-			break;
-#else
-			case KEY_CR:
-			break;
-			case KEY_LF:
-				new_line_handler(pThis);
-			break;
-#endif
 			//-----------------------------------------------------
 #ifdef _USE_COMPLETE
 			case KEY_HT:

--- a/src/microrl.h
+++ b/src/microrl.h
@@ -69,9 +69,7 @@ typedef struct {
 	char escape_seq;
 	char escape;
 #endif
-#if (defined(_ENDL_CRLF) || defined(_ENDL_LFCR))
-	char tmpch;
-#endif
+	char last_endl;                    // either 0 or the CR or LF that just triggered a newline
 #ifdef _USE_HISTORY
 	ring_history_t ring_hist;          // history object
 #endif


### PR DESCRIPTION
Triggers once on any of CR, LF, CRLF or LFCR.

When using a serial port interface to microrl, it's handy to use a fixed newline for output, but accept different newline combinations on input.