### PR TITLE
history: null-terminate restored history line

### DIFF
--- a/src/microrl.c
+++ b/src/microrl.c
@@ -363,6 +363,7 @@ static void hist_search (microrl_t * pThis, int dir)
 {
 	int len = hist_restore_line (&pThis->ring_hist, pThis->cmdline, dir);
 	if (len >= 0) {
+		pThis->cmdline[len] = '\0';
 		pThis->cursor = pThis->cmdlen = len;
 		terminal_reset_cursor (pThis);
 		terminal_print_line (pThis, 0, pThis->cursor);


### PR DESCRIPTION
(This Pull Request replaces #24, accidentally made on my 'master' branch instead of 'bugfix/null-terminate-restored-history-line.)

Fixes bug where scrolling past a longer line (foobar) before restoring a short line (baz) results in a combined command (bazbar) if the user ends the line without editing it.